### PR TITLE
Added Grind 75 to Interview Preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [github.com/odino/interviews](https://github.com/odino/interviews) : list of important questions for interview
 - [Give your résumé a face lift](http://www.lifeclever.com/give-your-resume-a-face-lift/)
 - [Google Interview Warmup](https://grow.google/certificates/interview-warmup/) : Google Interview Warmup is an AI-based tool that helps individuals practise for their interviews.
+- [Grind 75](https://www.techinterviewhandbook.org/grind75) : A LeetCode practice tool from [Tech Interview Handbook](techinterviewhandbook.org) that allows you to indicate your preferences for scheduling, difficulty, and topics and recommends the best LeetCode questions for you to practice.
 - [Here's How to Prepare for Tech Interviews • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1jov24/heres_how_to_prepare_for_tech_interviews/)
 - [How to Answer "Tell Me a Little About Yourself"/The Art of Manliness](http://www.artofmanliness.com/2016/01/05/tell-me-a-little-about-yourself/)
 - [How to Answer the Toughest 40 Job Interview Questions/ICS Job Portal](http://www.icsjobportal.com/blog/job-interview-questions)


### PR DESCRIPTION
I added a link to Grind 75, a Tech Interview Handbook tool, to the Interview Preparation section.

## Summary of your changes
I added a link to Grind 75 and a short description of the webpage under the Interview Preparation section of README.md.

### Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- If your changes closes an issue ticket, please refer it as: Fixes #<number> -->
I inserted a link to the Grind 75 webpage and a description of Grind 75's primary functionalities between the entries for Google Interview Warmup and "Here's How to Prepare for Tech Interviews" under Interview Preparation.

### Checklist

<!--- Please mark all options that apply to your case. -->

- [X] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [X] I have added only one new link to the list.
- [X] I have checked that the link that I added does NOT exist in the project already.
- [X] I have sorted the link alphabetically under the related section.
